### PR TITLE
Extract middleware and rule engine

### DIFF
--- a/server/middleware/logging.js
+++ b/server/middleware/logging.js
@@ -1,0 +1,6 @@
+const { systemLog } = require('../utils/fileLogger');
+
+module.exports = (req, res, next) => {
+  systemLog('API_CALL', `${req.method} ${req.url}`);
+  next();
+};

--- a/server/middleware/xmlParser.js
+++ b/server/middleware/xmlParser.js
@@ -1,0 +1,18 @@
+const xml2js = require('xml2js');
+const { systemLog, errorLog } = require('../utils/fileLogger');
+
+module.exports = (req, res, next) => {
+  if (req.is('application/xml')) {
+    systemLog('XML_RECEIVED', req.body ? req.body.substring(0, 200) : '');
+    xml2js.parseString(req.body, { explicitArray: false }, (err, result) => {
+      if (err) {
+        errorLog(err, 'XML parse failed');
+        return res.status(400).send('Invalid XML');
+      }
+      req.body = result;
+      next();
+    });
+  } else {
+    next();
+  }
+};

--- a/server/ruleEngine.js
+++ b/server/ruleEngine.js
@@ -1,0 +1,69 @@
+const Rule = require('./models/Rule');
+const { checkAggregateCondition } = require('./utils/aggregateChecker');
+
+function getField(obj, path) {
+  return path.split('.').reduce((o, p) => (o && o[p] != null ? o[p] : null), obj);
+}
+
+function checkCondition(obj, cond) {
+  const val = getField(obj, cond.field);
+  if (val == null) return false;
+  const str = String(val);
+  switch (cond.operator) {
+    case 'contains': return str.includes(cond.value);
+    case 'not contains': return !str.includes(cond.value);
+    case 'equals': return str === cond.value;
+    case 'regex': return new RegExp(cond.value).test(str);
+    case 'gt': return Number(str) > Number(cond.value);
+    case 'lt': return Number(str) < Number(cond.value);
+    default: return false;
+  }
+}
+
+async function runRules(parsed, raw) {
+  const rules = await Rule.find().sort({ priority: 1, createdAt: 1 });
+  const tags = [];
+  let matchedRuleName = null;
+  let finalAction = 'Allowed';
+
+  for (const r of rules) {
+    console.log('CHECKING RULE:', r.name);
+    const result = r.logic === 'AND'
+      ? r.conditions.every(cond => checkCondition(parsed, cond))
+      : r.conditions.some(cond => checkCondition(parsed, cond));
+    console.log('  Standard conditions:', result);
+    if (!result) continue;
+
+    if (r.aggregateConditions?.length > 0) {
+      const results = await Promise.all(
+        r.aggregateConditions.map(c => checkAggregateCondition(c, parsed))
+      );
+      const passed = r.logic === 'AND'
+        ? results.every(r => r)
+        : results.some(r => r);
+      console.log('  Aggregate conditions:', results, '=> passed:', passed);
+      if (!passed) continue;
+    }
+
+    if (r.action === 'Tag') {
+      if (r.tag) tags.push(r.tag);
+      continue;
+    }
+    if (!matchedRuleName || r.priority < 9999) {
+      matchedRuleName = r.name;
+      finalAction = r.action;
+      console.log('  MATCHED RULE:', matchedRuleName, 'Final action:', finalAction);
+      break;
+    }
+  }
+
+  if (!matchedRuleName) {
+    const low = raw.toLowerCase();
+    if (low.includes('ban')) finalAction = 'Forbidden';
+    else if (low.includes('allow') || low.includes('ok')) finalAction = 'Allowed';
+  }
+
+  return { finalAction, matchedRuleName, tags };
+}
+
+module.exports = { runRules };


### PR DESCRIPTION
## Summary
- move logging and XML parsing middleware into `server/middleware`
- extract rule evaluation logic into `server/ruleEngine.js`
- adapt `app.js` to use the new modules

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c2d2cfc2083269a5cf3f2ec0576f8